### PR TITLE
Fix google auth

### DIFF
--- a/src/components/GoogleSheetsApi.jsx
+++ b/src/components/GoogleSheetsApi.jsx
@@ -44,7 +44,7 @@ export default class GoogleSheetsApi extends Component {
     gapi.auth.authorize({
       'client_id': CLIENT_ID,
       'scope': SCOPES,
-      'immediate': true
+      'immediate': false
     }, (authResult) => {
       if (authResult.error) {
         this.setState({ googleAuthError: authResult })


### PR DESCRIPTION
This will fix logging in using Google when you don't already have any cookies set. I don't fully grasp why `immediate: true` doesn't work.