### PR TITLE
Don’t pass through people’s passwords in the URL

### DIFF
--- a/app/views/register.html
+++ b/app/views/register.html
@@ -15,7 +15,6 @@
         <h1 class="form-title heading-large">
               Create an account
         </h1>
-        <form action="email" class="form">
 
  
             <div class="form-group">
@@ -53,7 +52,7 @@
               <input class="form-control" data-module="" id="password" name="password" rows="8" type="password" value="">
             </div>
             
-          
+          <form action="email" class="form">
               <div class="form-group">
                      <input class="button" type="submit" value="Continue">
               </div>


### PR DESCRIPTION
When you submit a form as a `GET` request, any information that users enter into the form get appended to the query string in the  URL, eg `/email?name=chris&password=secret`

This is not great because people often reuse passwords, so people  using this prototype could inadvertently be revealing their passwords to anyone watching.

By not including any of the `<input>` fields inside the form their contents won't be passed through to the next page.